### PR TITLE
Add filter for moves that put king in check

### DIFF
--- a/server/pkg/models/board/board_test.go
+++ b/server/pkg/models/board/board_test.go
@@ -87,7 +87,7 @@ func TestKnightMoves(t *testing.T) {
 		expectedLegalMoves MoveMap
 	}{
 		{
-			name:     "Knight in the middle of the ",
+			name:     "Knight in the middle of the board.",
 			position: Position{Rank: 3, File: 3},
 			piece:    NewKnight(WHITE),
 			expectedLegalMoves: MoveMap{
@@ -136,7 +136,7 @@ func TestQueenMoves(t *testing.T) {
 		expectedLegalMoves MoveMap
 	}{
 		{
-			name:     "Queen in the middle of the ",
+			name:     "Queen in the middle of the board.",
 			position: Position{Rank: 3, File: 3},
 			piece:    NewQueen(WHITE, bounds),
 			expectedLegalMoves: MoveMap{
@@ -221,7 +221,7 @@ func TestKingMoves(t *testing.T) {
 		expectedLegalMoves MoveMap
 	}{
 		{
-			name:     "King in the middle of the ",
+			name:     "King in the middle of the board.",
 			position: Position{Rank: 4, File: 4},
 			piece:    NewKing(WHITE),
 			expectedLegalMoves: MoveMap{
@@ -314,7 +314,7 @@ func TestRookMoves(t *testing.T) {
 		expectedLegalMoves MoveMap
 	}{
 		{
-			name:     "Rook in the middle of the ",
+			name:     "Rook in the middle of the board.",
 			position: Position{Rank: 3, File: 3},
 			piece:    NewRook(WHITE, bounds),
 			expectedLegalMoves: MoveMap{
@@ -371,7 +371,7 @@ func TestBishopMoves(t *testing.T) {
 		expectedLegalMoves MoveMap
 	}{
 		{
-			name:     "Bishop in the middle of the ",
+			name:     "Bishop in the middle of the board.",
 			position: Position{Rank: 3, File: 3},
 			piece:    NewBishop(WHITE, bounds),
 			expectedLegalMoves: MoveMap{
@@ -691,8 +691,8 @@ func TestHandleMove(t *testing.T) {
 		}
 
 		// Check that the board is in the expected state.
-		if !reflect.DeepEqual(board.CastlingState, tc.expectedBoard.CastlingState) {
-			t.Errorf("Test case %s: expected board %v but got %v", tc.name, tc.expectedBoard.CastlingState, board.CastlingState)
+		if !reflect.DeepEqual(board.GameboardState, tc.expectedBoard.GameboardState) {
+			t.Errorf("Test case %s: expected board %v but got %v", tc.name, tc.expectedBoard, board)
 		}
 	}
 }

--- a/server/pkg/models/board/move_generators.go
+++ b/server/pkg/models/board/move_generators.go
@@ -6,7 +6,7 @@ type SingleNormalMoveGenerator struct {
 	direction Direction
 }
 
-func (g *SingleNormalMoveGenerator) GetMoves(source Position) MoveMap {
+func (g *SingleNormalMoveGenerator) GenerateMoves(source Position) MoveMap {
 	return map[MoveType][]Position{
 		NORMAL: {
 			StepInDirection(source, g.direction),
@@ -20,7 +20,7 @@ type SingleDiagonalCaputureMoveGenerator struct {
 	color Color
 }
 
-func (g *SingleDiagonalCaputureMoveGenerator) GetMoves(source Position) MoveMap {
+func (g *SingleDiagonalCaputureMoveGenerator) GenerateMoves(source Position) MoveMap {
 	var rankDirection int
 	if g.color == WHITE {
 		rankDirection = 1
@@ -42,7 +42,7 @@ type DoublePushMoveGenerator struct {
 	color Color
 }
 
-func (g *DoublePushMoveGenerator) GetMoves(source Position) MoveMap {
+func (g *DoublePushMoveGenerator) GenerateMoves(source Position) MoveMap {
 	var rankDirection int
 	if g.color == WHITE {
 		rankDirection = 1
@@ -61,7 +61,7 @@ func (g *DoublePushMoveGenerator) GetMoves(source Position) MoveMap {
 // in one direction and one square in an orthogonal direction.
 type KnightMoveGenerator struct{}
 
-func (g *KnightMoveGenerator) GetMoves(source Position) MoveMap {
+func (g *KnightMoveGenerator) GenerateMoves(source Position) MoveMap {
 	moves := map[MoveType][]Position{
 		JUMP:         {},
 		JUMP_CAPTURE: {},
@@ -93,7 +93,7 @@ type RayMoveGenerator struct {
 	bounds    Bounds
 }
 
-func (g *RayMoveGenerator) GetMoves(source Position) MoveMap {
+func (g *RayMoveGenerator) GenerateMoves(source Position) MoveMap {
 	ray := GenerateRay(source, g.direction, g.bounds)
 	return map[MoveType][]Position{
 		NORMAL:  ray,
@@ -106,7 +106,7 @@ type CastleMoveGenerator struct {
 	color Color
 }
 
-func (g *CastleMoveGenerator) GetMoves(source Position) MoveMap {
+func (g *CastleMoveGenerator) GenerateMoves(source Position) MoveMap {
 	moves := map[MoveType][]Position{
 		KINGSIDE_CASTLE:  {},
 		QUEENSIDE_CASTLE: {},

--- a/server/pkg/models/board/move_handlers.go
+++ b/server/pkg/models/board/move_handlers.go
@@ -25,13 +25,19 @@ func NewMoveApplicator(moveHandlers ...moveApplicator) *MoveApplicator {
 	return newMoveApplicator
 }
 
-func (h *MoveApplicator) ApplyMove(move Move, state GameboardState) error {
+func (h *MoveApplicator) ApplyMove(move Move, state GameboardState) (GameboardState, error) {
 	handler, ok := h.moveApplicatorMap[move.MoveType]
 	if !ok {
-		return errCannotHandleMoveType(move.MoveType)
+		return nil, errCannotHandleMoveType(move.MoveType)
 	}
 
-	return handler.ApplyMove(move, state)
+	stateCopy := CopyGameboardState(state)
+	err := handler.ApplyMove(move, stateCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return stateCopy, nil
 }
 
 // SinglePieceMoveApplicator applies a single piece movement to a StateMap.

--- a/server/pkg/models/board/piece.go
+++ b/server/pkg/models/board/piece.go
@@ -1,7 +1,7 @@
 package board
 
 type moveGenerator interface {
-	GetMoves(source Position) MoveMap
+	GenerateMoves(source Position) MoveMap
 }
 
 // Piece is used to represent a movable entity on a board.
@@ -23,12 +23,24 @@ func (p *Piece) GetType() PieceType {
 }
 
 // GetMoves returns a list of possible moves for the Piece at the given position.
-func (p *Piece) GetMoves(source Position) MoveMap {
+func (p *Piece) GenerateMoves(source Position) MoveMap {
 	moveMap := NewMoveMap()
 	for _, generator := range p.moveGenerators {
-		JoinMoveMaps(moveMap, generator.GetMoves(source))
+		JoinMoveMaps(moveMap, generator.GenerateMoves(source))
 	}
 	return moveMap
+}
+
+// IsAvailableMove returns true if the provided moveDestination is an AvailableMove.
+func (p *Piece) IsAvailableMove(move Move) bool {
+	if destinations, ok := p.AvailableMoves[move.MoveType]; ok {
+		for _, availableDestination := range destinations {
+			if move.Destination == availableDestination {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // NewPiece creates a new Piece based on the input parameters.

--- a/server/pkg/models/board/state_filters.go
+++ b/server/pkg/models/board/state_filters.go
@@ -1,0 +1,97 @@
+package board
+
+type illegalStateFilter interface {
+	IsLegalState(color Color, state GameboardState, availableMoveMap AvailableMoveMap) bool
+}
+
+// IllegalStateFilter bundles multiple IllegalStateFilter into a single struct.
+type IllegalStateFilter struct {
+	illegalStateFilters []illegalStateFilter
+}
+
+func (i *IllegalStateFilter) IsLegalState(
+	color Color,
+	state GameboardState,
+	availableMoveMap AvailableMoveMap,
+) bool {
+	for _, filter := range i.illegalStateFilters {
+		if !filter.IsLegalState(color, state, availableMoveMap) {
+			return false
+		}
+	}
+	return true
+}
+
+func NewIllegalStateFilter(illegalStateFilters ...illegalStateFilter) *IllegalStateFilter {
+	return &IllegalStateFilter{
+		illegalStateFilters: illegalStateFilters,
+	}
+}
+
+// IllegalCheckStateFilter is used to verify if a king is in check.
+type IllegalCheckStateFilter struct{}
+
+// IsLegalState checks is the provided Color's king is in check.
+func (s *IllegalCheckStateFilter) IsLegalState(
+	color Color,
+	state GameboardState,
+	availableMoveMap AvailableMoveMap,
+) bool {
+	return !s.anyPosition(
+		color,
+		state,
+		s.PredicateAttackingEnemyKing(color, state, availableMoveMap),
+	)
+}
+
+// PredicateAttackingEnemyKing returns a positionPredicate that checks
+// if the provided piece is attacking an enemy king.
+func (s *IllegalCheckStateFilter) PredicateAttackingEnemyKing(
+	kingColor Color,
+	state GameboardState,
+	availableMoves AvailableMoveMap,
+) positionPredicate {
+	return func(position Position, state GameboardState) bool {
+		moves := availableMoves[position.Rank][position.File]
+		if moves == nil {
+			return false
+		}
+
+		capturingMoveTypes := []MoveType{CAPTURE, JUMP_CAPTURE}
+		for _, moveType := range capturingMoveTypes {
+			if movesByType, ok := moves[moveType]; ok {
+				for _, destination := range movesByType {
+					destinationPiece := state[destination.Rank][destination.File]
+					if destinationPiece != nil &&
+						destinationPiece.PieceType == KING &&
+						destinationPiece.Color == kingColor {
+						return true
+					}
+				}
+			}
+		}
+
+		return false
+	}
+}
+
+// positionPredicate returns true if the position satisfies the predicate.
+type positionPredicate = func(position Position, state GameboardState) bool
+
+// anyPosition applies the predicate to each position on the board,
+// returns true if any position satisfies the predicate.
+func (s *IllegalCheckStateFilter) anyPosition(
+	kingColor Color,
+	state GameboardState,
+	pred positionPredicate,
+) bool {
+	for rank, files := range state {
+		for file := range files {
+			result := pred(Position{Rank: rank, File: file}, state)
+			if result {
+				return result
+			}
+		}
+	}
+	return false
+}

--- a/server/pkg/models/board/state_filters_test.go
+++ b/server/pkg/models/board/state_filters_test.go
@@ -1,0 +1,164 @@
+package board
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIllegalCheckStateFilter(t *testing.T) {
+	bounds := Bounds{RankCount: 8, FileCount: 8}
+	testcases := []struct {
+		name                 string
+		color                Color
+		state                GameboardState
+		availableMoveMap     AvailableMoveMap
+		expectedIsLegalState bool
+	}{
+		{
+			name:                 "Empty board is legal state.",
+			color:                WHITE,
+			state:                NewGameboardState(bounds, GameboardState{}),
+			availableMoveMap:     NewAvailableMoveMap(bounds),
+			expectedIsLegalState: true,
+		},
+		{
+			name:  "Only king on board is legal state.",
+			color: BLACK,
+			state: NewGameboardState(
+				bounds,
+				GameboardState{
+					0: {
+						0: NewKing(BLACK),
+					},
+				}),
+			availableMoveMap:     NewAvailableMoveMap(bounds),
+			expectedIsLegalState: true,
+		},
+		{
+			name:  "King in check via CAPTURE is illegal state.",
+			color: BLACK,
+			state: NewGameboardState(
+				bounds,
+				GameboardState{
+					0: {
+						0: NewKing(BLACK),
+						7: NewRook(WHITE, bounds),
+					},
+				}),
+			availableMoveMap: AvailableMoveMap{
+				0: {
+					7: MoveMap{
+						CAPTURE: []Position{
+							{Rank: 0, File: 0},
+						},
+					},
+				},
+			},
+			expectedIsLegalState: false,
+		},
+		{
+			name:  "King in check via JUMP_CAPTURE is illegal state.",
+			color: BLACK,
+			state: NewGameboardState(
+				bounds,
+				GameboardState{
+					0: {
+						0: NewKing(BLACK),
+						1: NewQueen(BLACK, bounds),
+					},
+					2: {
+						1: NewKnight(WHITE),
+					},
+				}),
+			availableMoveMap: AvailableMoveMap{
+				0: {
+					7: MoveMap{
+						JUMP_CAPTURE: []Position{
+							{Rank: 0, File: 0},
+						},
+					},
+				},
+			},
+			expectedIsLegalState: false,
+		},
+		{
+			name:  "King in check but other color is legal state.",
+			color: WHITE,
+			state: NewGameboardState(
+				bounds,
+				GameboardState{
+					0: {
+						0: NewKing(BLACK),
+						7: NewRook(WHITE, bounds),
+					},
+				}),
+			availableMoveMap: AvailableMoveMap{
+				0: {
+					7: MoveMap{
+						CAPTURE: []Position{
+							{Rank: 0, File: 0},
+						},
+					},
+				},
+			},
+			expectedIsLegalState: true,
+		},
+		{
+			name:  "Capturing non-king piece is legal state.",
+			color: BLACK,
+			state: NewGameboardState(
+				bounds,
+				GameboardState{
+					0: {
+						0: NewKing(BLACK),
+						1: NewQueen(BLACK, bounds),
+						7: NewRook(WHITE, bounds),
+					},
+				}),
+			availableMoveMap: AvailableMoveMap{
+				0: {
+					7: MoveMap{
+						CAPTURE: []Position{
+							{Rank: 0, File: 1},
+						},
+					},
+				},
+			},
+			expectedIsLegalState: true,
+		},
+		{
+			name:  "Jump capturing non-king piece is legal state.",
+			color: BLACK,
+			state: NewGameboardState(
+				bounds,
+				GameboardState{
+					0: {
+						0: NewKing(BLACK),
+						1: NewQueen(BLACK, bounds),
+					},
+					2: {
+						2: NewKnight(WHITE),
+					},
+				}),
+			availableMoveMap: AvailableMoveMap{
+				0: {
+					7: MoveMap{
+						JUMP_CAPTURE: []Position{
+							{Rank: 0, File: 1},
+						},
+					},
+				},
+			},
+			expectedIsLegalState: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			illegalCheckStateFilter := IllegalCheckStateFilter{}
+			isLegalState := illegalCheckStateFilter.IsLegalState(tc.color, tc.state, tc.availableMoveMap)
+			assert.Equal(t, tc.expectedIsLegalState, isLegalState)
+		})
+	}
+}


### PR DESCRIPTION
Closes: #119
Closes: #138 

This PR includes:
- Making move application and filtering more functional
- Add illegal state checks (only includes check state now)

Follow ups:
- Add game end (active player has no moves i.e. checkmate / stalemate)
- Add checks for castling through check